### PR TITLE
Add Maven for build and initial unit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/io/modelcontextprotocol/server/McpServer.java
+++ b/src/main/java/io/modelcontextprotocol/server/McpServer.java
@@ -144,7 +144,7 @@ public class McpServer {
                     }
                     LOGGER.info("Shutdown request received. Responding and awaiting exit notification.");
                     this.initialized.set(false);
-                    response = new JsonRpcResponse(request.getId(), null);
+                    response = new JsonRpcResponse(request.getId(), (JsonElement) null);
                     transport.writeMessage(response);
                     return;
 

--- a/src/test/java/io/modelcontextprotocol/server/tools/EchoToolTest.java
+++ b/src/test/java/io/modelcontextprotocol/server/tools/EchoToolTest.java
@@ -1,0 +1,80 @@
+package io.modelcontextprotocol.server.tools;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import io.modelcontextprotocol.server.jsonrpc.JsonRpcException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class EchoToolTest {
+
+    private EchoTool echoTool;
+
+    @Before
+    public void setUp() {
+        echoTool = new EchoTool();
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals("echoTool", echoTool.getName());
+    }
+
+    @Test
+    public void testGetDescription() {
+        assertEquals("A simple tool that takes a 'message' string and returns it prefixed with 'Echo: '.", echoTool.getDescription());
+    }
+
+    @Test
+    public void testCallSuccessful() throws JsonRpcException {
+        JsonObject params = new JsonObject();
+        params.addProperty("message", "Hello");
+
+        JsonObject result = echoTool.call(params);
+
+        assertNotNull(result);
+        assertEquals("Echo: Hello", result.get("response").getAsString());
+    }
+
+    @Test
+    public void testCallMissingMessageParameter() {
+        JsonObject params = new JsonObject();
+        // "message" parameter is missing
+        try {
+            echoTool.call(params);
+            fail("Expected JsonRpcException for missing parameter");
+        } catch (JsonRpcException e) {
+            assertEquals(-32602, e.getErrorCode()); // Invalid Params
+            assertEquals("Parameter 'message' is missing for echoTool", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCallNullParameters() {
+        try {
+            echoTool.call(null);
+            fail("Expected JsonRpcException for null parameters");
+        } catch (JsonRpcException e) {
+            assertEquals(-32602, e.getErrorCode()); // Invalid Params
+            assertEquals("Parameter 'message' is missing for echoTool", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCallMessageParameterNotString() {
+        JsonObject params = new JsonObject();
+        params.add("message", new JsonPrimitive(123)); // Not a string
+
+        try {
+            echoTool.call(params);
+            fail("Expected JsonRpcException for non-string message parameter");
+        } catch (JsonRpcException e) {
+            assertEquals(-32602, e.getErrorCode()); // Invalid Params
+            assertEquals("Parameter 'message' must be a string for echoTool", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This change introduces Maven to the project for managing dependencies and the build lifecycle.

Key changes:
- Added `pom.xml` with configurations for compilation and testing.
- Included JUnit and Gson as dependencies.
- Created the `src/test/java` directory structure for tests.
- Added `EchoToolTest.java` with unit tests for the `EchoTool` class.
- Made minor adjustments to `McpServer.java` and `EchoToolTest.java` to ensure a successful Maven build.

The project can now be built using `mvn clean install`.